### PR TITLE
Silence visibility warnings with 'public' modifier

### DIFF
--- a/src/warp.sol
+++ b/src/warp.sol
@@ -22,15 +22,15 @@ import "ds-note/note.sol";
 contract DSWarp is DSNote {
     uint64  _era;
 
-    function DSWarp() {
+    function DSWarp() public {
         _era = uint64(now);
     }
 
-    function era() constant returns (uint64) {
+    function era() public view returns (uint64) {
         return _era == 0 ? uint64(now) : _era;
     }
 
-    function warp(uint64 age) note {
+    function warp(uint64 age) note public {
         require(_era != 0);
         _era = age == 0 ? 0 : _era + age;
     }

--- a/src/warp.t.sol
+++ b/src/warp.t.sol
@@ -23,22 +23,22 @@ import "./warp.sol";
 contract DSWarpTest is DSTest {
     DSWarp warp;
 
-    function setUp() {
+    function setUp() public {
         warp = new DSWarp();
     }
-    function testInit() {
+    function testInit() public {
         assertEq(warp.era(), now);
     }
-    function testWarp() {
+    function testWarp() public {
         var tic = now;
         warp.warp(1);
         assertEq(warp.era(), tic + 1);
     }
-    function testWarpLock() {
+    function testWarpLock() public {
         warp.warp(0);
         assertEq(warp.era(), now);
     }
-    function testFailAfterWarpLock() {
+    function testFailAfterWarpLock() public {
         warp.warp(0);
         warp.warp(1);
     }


### PR DESCRIPTION
This silences warnings such as

```
src/warp.t.sol:32:5: Warning: No visibility specified. Defaulting to "public".
    function testWarp() {
```